### PR TITLE
Add a Content-Type header for form encoding

### DIFF
--- a/src/scripts/webhook.coffee
+++ b/src/scripts/webhook.coffee
@@ -54,6 +54,7 @@ class Webhook
       when 'GET'
         http.query(params).get()
       else
+        http.header 'Content-Type', 'application/x-www-form-urlencoded'
         http.post(Qs.stringify params)
 
   signatureFor: (params) ->


### PR DESCRIPTION
This fixes a bug where if PHP is the language of the webhook receiver, the params are not properly parsed into $_POST variable.